### PR TITLE
Add additional pagination parameters to some company endpoints

### DIFF
--- a/src/Api/Companies.php
+++ b/src/Api/Companies.php
@@ -9,6 +9,8 @@ class Companies extends Api
      * Create a company
      * @param array $properties Array of company properties.
      *
+     * @link http://developers.hubspot.com/docs/methods/companies/create_company
+     *
      * @return \Fungku\HubSpot\Http\Response
      */
     public function create($properties)
@@ -24,6 +26,8 @@ class Companies extends Api
      * @param int $id The company id.
      * @param array $properties The company properties to update.
      *
+     * @link http://developers.hubspot.com/docs/methods/companies/update_company
+     *
      * @return \Fungku\HubSpot\Http\Response
      */
     public function update($id, $properties)
@@ -38,6 +42,8 @@ class Companies extends Api
      * Deletes a company
      * @param int $id The company id
      *
+     * @link http://developers.hubspot.com/docs/methods/companies/delete_company
+     *
      * @return \Fungku\HubSpot\Http\Response
      */
     public function delete($id)
@@ -50,6 +56,8 @@ class Companies extends Api
     /**
      * Returns the recently modified companies
      * @param array $params Array of optional parameters ['count', 'offset']
+     *
+     * @link http://developers.hubspot.com/docs/methods/companies/get_companies_modified
      *
      * @return \Fungku\HubSpot\Http\Response
      */
@@ -66,6 +74,8 @@ class Companies extends Api
      * Returns the recently created companies
      * @param array $params Array of optional parameters ['count', 'offset']
      *
+     * @link http://developers.hubspot.com/docs/methods/companies/get_companies_created
+     *
      * @return \Fungku\HubSpot\Http\Response
      */
     public function getRecentlyCreated($params = [])
@@ -81,6 +91,8 @@ class Companies extends Api
      * Returns an array of companies that have a matching domain
      * @param string $domain The domain of the company eq. 'example.com'.
      *
+     * @link http://developers.hubspot.com/docs/methods/companies/get_companies_by_domain
+     *
      * @return \Fungku\HubSpot\Http\Response
      */
     public function getByDomain($domain)
@@ -93,6 +105,8 @@ class Companies extends Api
     /**
      * Returns a company with id $id
      * @param int $id
+     *
+     * @link http://developers.hubspot.com/docs/methods/companies/get_company
      *
      * @return \Fungku\HubSpot\Http\Response
      */
@@ -109,6 +123,8 @@ class Companies extends Api
      * @param int $contactId
      * @param int $companyId
      *
+     * @link http://developers.hubspot.com/docs/methods/companies/add_contact_to_company
+     *
      * @return \Fungku\HubSpot\Http\Response
      */
     public function addContact($contactId, $companyId)
@@ -122,6 +138,8 @@ class Companies extends Api
      * Returns an array of the associated contacts for the given company
      * @param int $companyId The id of the company.
      * @param array $params Array of optional parameters ['count', 'vidOffset']
+     *
+     * @link http://developers.hubspot.com/docs/methods/companies/get_company_contacts
      *
      * @return \Fungku\HubSpot\Http\Response
      */
@@ -139,6 +157,8 @@ class Companies extends Api
      * @param int $companyId The id of the company.
      * @param array $params Array of optional parameters ['count', 'vidOffset']
      *
+     * @link http://developers.hubspot.com/docs/methods/companies/get_company_contacts_by_id
+     *
      * @return \Fungku\HubSpot\Http\Response
      */
     public function getAssociatedContactIds($companyId, $params = [])
@@ -154,6 +174,8 @@ class Companies extends Api
      * Removes a contact from a company
      * @param int $contactId
      * @param int $companyId
+     *
+     * @link http://developers.hubspot.com/docs/methods/companies/remove_contact_from_company
      *
      * @return \Fungku\HubSpot\Http\Response
      */

--- a/src/Api/Companies.php
+++ b/src/Api/Companies.php
@@ -49,26 +49,32 @@ class Companies extends Api
 
     /**
      * Returns the recently modified companies
+     * @param array $params Array of optional parameters ['count', 'offset']
      *
      * @return \Fungku\HubSpot\Http\Response
      */
-    public function getRecentlyModified()
+    public function getRecentlyModified($params = [])
     {
         $endpoint = '/companies/v2/companies/recent/modified';
 
-        return $this->request('get', $endpoint);
+        $queryString = $this->buildQueryString($params);
+
+        return $this->request('get', $endpoint, [], $queryString);
     }
 
     /**
      * Returns the recently created companies
+     * @param array $params Array of optional parameters ['count', 'offset']
      *
      * @return \Fungku\HubSpot\Http\Response
      */
-    public function getRecentlyCreated()
+    public function getRecentlyCreated($params = [])
     {
         $endpoint = '/companies/v2/companies/recent/created';
 
-        return $this->request('get', $endpoint);
+        $queryString = $this->buildQueryString($params);
+
+        return $this->request('get', $endpoint, [], $queryString);
     }
 
     /**
@@ -114,28 +120,34 @@ class Companies extends Api
 
     /**
      * Returns an array of the associated contacts for the given company
-     * @param int $id The id of the company.
+     * @param int $companyId The id of the company.
+     * @param array $params Array of optional parameters ['count', 'vidOffset']
      *
      * @return \Fungku\HubSpot\Http\Response
      */
-    public function getAssociatedContacts($id)
+    public function getAssociatedContacts($companyId, $params = [])
     {
-        $endpoint = "/companies/v2/companies/{$id}/contacts";
+        $endpoint = "/companies/v2/companies/{$companyId}/contacts";
 
-        return $this->request('get', $endpoint);
+        $queryString = $this->buildQueryString($params);
+
+        return $this->request('get', $endpoint, [], $queryString);
     }
 
     /**
      * Returns all of the contact IDs who are associated with the given company
-     * @param int $id The id of the company.
+     * @param int $companyId The id of the company.
+     * @param array $params Array of optional parameters ['count', 'vidOffset']
      *
      * @return \Fungku\HubSpot\Http\Response
      */
-    public function getAssociatedContactIds($id)
+    public function getAssociatedContactIds($companyId, $params = [])
     {
-        $endpoint = "/companies/v2/companies/{$id}/vids";
+        $endpoint = "/companies/v2/companies/{$companyId}/vids";
 
-        return $this->request('get', $endpoint);
+        $queryString = $this->buildQueryString($params);
+
+        return $this->request('get', $endpoint, [], $queryString);
     }
 
     /**

--- a/tests/integration/Api/CompaniesTest.php
+++ b/tests/integration/Api/CompaniesTest.php
@@ -73,12 +73,33 @@ class CompaniesTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function getRecentlyModifiedWithCountAndOffset()
+    {
+        $params = ['count' => 2, 'offset' => 1];
+        $response = $this->companies->getRecentlyModified($params);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertCount(2, $response['results']);
+        $this->assertEquals(3, $response['offset']);
+    }
+
+    /** @test */
     public function getRecentlyCreated()
     {
         $response = $this->companies->getRecentlyCreated();
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertGreaterThan(2, $response['results']);
+    }
+
+    /** @test */
+    public function getRecentlyCreatedWithCountAndOffset()
+    {
+        $params = ['count' => 2, 'offset' => 1];
+        $response = $this->companies->getRecentlyCreated($params);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertCount(2, $response['results']);
+        $this->assertEquals(3, $response['offset']);
     }
 
     /** @test */
@@ -133,6 +154,25 @@ class CompaniesTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $response['contacts']);
         $this->assertEquals($contactId, $response['contacts'][0]['vid']);
     }
+    
+    /** @test */
+    public function getAssociatedContactsWithCountAndOffset()
+    {
+        $newCompanyResponse = $this->createCompany();
+        $companyId = $newCompanyResponse['companyId'];
+        list($contactId) = $this->createAssociatedContact($companyId);
+        list($contactId2) = $this->createAssociatedContact($companyId);
+
+        $response = $this->companies->getAssociatedContacts($companyId, ['count' => 1, 'vidOffset' => $contactId ]);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertCount(1, $response['contacts']);
+
+
+        $offsetResponse = $this->companies->getAssociatedContacts($companyId, ['count' => 1, 'vidOffset' => $contactId2 + 1 ]);
+        $this->assertEquals(200, $offsetResponse->getStatusCode());
+        $this->assertTrue(empty($offsetResponse['contacts']));
+        $this->assertEquals($contactId2 + 1, $offsetResponse['vidOffset']);
+    }
 
     /** @test */
     public function getAssociatedContactIds()
@@ -146,9 +186,27 @@ class CompaniesTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertGreaterThanOrEqual(1, $response['vids']);
-        // $this->assertContains($contactId1, $response['vids']);
-//        $this->assertContains($contactId2, $response['vids']);
+        $this->assertContains($contactId1, $response['vids']);
+        $this->assertContains($contactId2, $response['vids']);
 
+    }
+
+    /** @test */
+    public function getAssociatedContactIdsWithCountAndOffset()
+    {
+        $newCompanyResponse = $this->createCompany();
+        $companyId = $newCompanyResponse['companyId'];
+        list($contactId1) = $this->createAssociatedContact($companyId);
+        list($contactId2) = $this->createAssociatedContact($companyId);
+
+        $response = $this->companies->getAssociatedContactIds($companyId, ['count' => 1]);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertCount(1, $response['vids']);
+
+        $offsetResponse = $this->companies->getAssociatedContactIds($companyId, ['count' => 1, 'vidOffset' => $contactId2]);
+        $this->assertEquals(200, $offsetResponse->getStatusCode());
+        $this->assertCount(1, $offsetResponse['vids']);
+        $this->assertEquals($contactId2, $offsetResponse['vidOffset']);
     }
 
     /** @test */

--- a/tests/integration/Api/CompaniesTest.php
+++ b/tests/integration/Api/CompaniesTest.php
@@ -203,10 +203,10 @@ class CompaniesTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertCount(1, $response['vids']);
 
-        $offsetResponse = $this->companies->getAssociatedContactIds($companyId, ['count' => 1, 'vidOffset' => $contactId2]);
+        $offsetResponse = $this->companies->getAssociatedContactIds($companyId, ['count' => 1, 'vidOffset' => $contactId2 + 1]);
         $this->assertEquals(200, $offsetResponse->getStatusCode());
-        $this->assertCount(1, $offsetResponse['vids']);
-        $this->assertEquals($contactId2, $offsetResponse['vidOffset']);
+        $this->assertTrue(empty($offsetResponse['vids']));
+        $this->assertEquals($contactId2 + 1, $offsetResponse['vidOffset']);
     }
 
     /** @test */

--- a/tests/spec/Api/CompaniesSpec.php
+++ b/tests/spec/Api/CompaniesSpec.php
@@ -94,6 +94,17 @@ class CompaniesSpec extends ObjectBehavior
         $this->getRecentlyModified()->shouldReturn('response');
     }
 
+    function it_can_also_define_count_and_offset_for_recently_modified_companies($client)
+    {
+        $url = $this->buildUrl('/companies/v2/companies/recent/modified', '&offset=1&count=2');
+
+        $client->get($url, [
+            'headers' => $this->headers
+        ])->shouldBeCalled()->willReturn('response');
+
+        $this->getRecentlyModified(['offset' => 1, 'count' => 2])->shouldReturn('response');
+    }
+
     function it_can_get_recently_created_companies($client)
     {
         $url = $this->buildUrl('/companies/v2/companies/recent/created');
@@ -104,6 +115,17 @@ class CompaniesSpec extends ObjectBehavior
 
         $this->getRecentlyCreated()->shouldReturn('response');
 
+    }
+
+    function it_can_also_define_count_and_offset_for_recently_created_companies($client)
+    {
+        $url = $this->buildUrl('/companies/v2/companies/recent/created', '&offset=1&count=2');
+
+        $client->get($url, [
+            'headers' => $this->headers
+        ])->shouldBeCalled()->willReturn('response');
+
+        $this->getRecentlyCreated(['offset' => 1, 'count' => 2])->shouldReturn('response');
     }
 
     function it_can_get_companies_by_domain($client)
@@ -148,28 +170,54 @@ class CompaniesSpec extends ObjectBehavior
 
     function it_can_get_contacts_associated_with_the_company($client)
     {
-        $id = 10444744;
+        $compnayId = 10444744;
 
-        $url = $this->buildUrl("/companies/v2/companies/{$id}/contacts");
+        $url = $this->buildUrl("/companies/v2/companies/{$compnayId}/contacts");
 
         $client->get($url, [
             'headers' => $this->headers
         ])->shouldBeCalled()->willReturn('response');
 
-        $this->getAssociatedContacts($id)->shouldReturn('response');
+        $this->getAssociatedContacts($compnayId)->shouldReturn('response');
+    }
+
+    function it_can_also_define_count_and_vidOffset_for_associated_contacts($client)
+    {
+        $companyId = 10444744;
+
+        $url = $this->buildUrl("/companies/v2/companies/{$companyId}/contacts", '&count=1&vidOffset=2');
+
+        $client->get($url, [
+            'headers' => $this->headers
+        ])->shouldBeCalled()->willReturn('response');
+
+        $this->getAssociatedContacts($companyId, ['count' => 1, 'vidOffset' => 2])->shouldReturn('response');
     }
 
     function it_can_get_the_ids_of_the_contacts_associated_with_the_company($client)
     {
-        $id = 10444744;
+        $companyId = 10444744;
 
-        $url = $this->buildUrl("/companies/v2/companies/{$id}/vids");
+        $url = $this->buildUrl("/companies/v2/companies/{$companyId}/vids");
 
         $client->get($url, [
             'headers' => $this->headers
         ])->shouldBeCalled()->willReturn('response');
 
-        $this->getAssociatedContactIds($id)->shouldReturn('response');
+        $this->getAssociatedContactIds($companyId)->shouldReturn('response');
+    }
+
+    function it_can_also_define_count_and_vidOffset_for_associated_contact_ids($client)
+    {
+        $companyId = 10444744;
+
+        $url = $this->buildUrl("/companies/v2/companies/{$companyId}/vids", '&count=1&vidOffset=2');
+
+        $client->get($url, [
+            'headers' => $this->headers
+        ])->shouldBeCalled()->willReturn('response');
+
+        $this->getAssociatedContactIds($companyId,  ['count' => 1, 'vidOffset' => 2])->shouldReturn('response');
     }
 
     function it_can_remove_a_contact_from_a_company($client)


### PR DESCRIPTION
- getRecentlyModified
- getRecentlyCreated
- getAssociatedContacts
- getAssociatedContactIds

Were missing additional pagination parameters. I also commented back couple of assertions. The hubspot API seems to randomly produce the errors, not the tests? 