### PR TITLE
Guzzle v6 requires to use 'form_params' instead of 'body' in options

### DIFF
--- a/src/Api/Forms.php
+++ b/src/Api/Forms.php
@@ -21,7 +21,7 @@ class Forms extends Api
     {
         $url = "https://forms.hubspot.com/uploads/form/v2/{$portal_id}/{$form_guid}";
 
-        $options['body'] = $form;
+        $options['form_params'] = $form;
 
         return $this->requestUrl('post', $url, $options);
     }

--- a/tests/integration/Api/FormsTest.php
+++ b/tests/integration/Api/FormsTest.php
@@ -7,6 +7,9 @@ use Fungku\HubSpot\Http\Client;
 
 class FormsTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Forms
+     */
     private $forms;
 
     public function setUp()
@@ -119,5 +122,17 @@ class FormsTest extends \PHPUnit_Framework_TestCase
         $response = $this->forms->getFieldByName($form->guid, 'firstname');
 
         $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /** @test */
+    public function submit()
+    {
+        $form = $this->createForm();
+
+        $response = $this->forms->submit(62515, $form->guid, [
+            'firstname' => 'FooBar'
+        ]);
+
+        $this->assertEquals(204, $response->getStatusCode());
     }
 }


### PR DESCRIPTION
Fixes #33 