### PR TITLE
Fix workflow enrollment using incorrect HTTP verb

### DIFF
--- a/src/Api/Workflows.php
+++ b/src/Api/Workflows.php
@@ -40,7 +40,7 @@ class Workflows extends Api
     {
         $endpoint = "/automation/v2/workflows/{$workflow_id}/enrollments/contacts/{$email}";
 
-        return $this->request('get', $endpoint);
+        return $this->request('post', $endpoint);
     }
 
     /**


### PR DESCRIPTION
Workflow enrollment was using GET instead of POST, as per hubspot documentation: http://developers.hubspot.com/docs/methods/workflows/add_contact