### PR TITLE
Fix Files all request to match expected format

### DIFF
--- a/src/Resources/Files.php
+++ b/src/Resources/Files.php
@@ -38,10 +38,11 @@ class Files extends Resource
     {
         $endpoint = "https://api.hubapi.com/filemanager/api/v2/files";
 
-        $options['json'] = $params;
+        $queryString = build_query_string($params);
 
-        return $this->client->request('get', $endpoint, $options);
+        return $this->client->request('get', $endpoint, [], $queryString);
     }
+
 
     /**
      * Upload a replacement file.


### PR DESCRIPTION
Change the Files::all() method to use a query string for options instead of a JSON body.