### PR TITLE
Single Send API Support

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -29,6 +29,7 @@ use SevenShores\Hubspot\Http\Client;
  * @method \SevenShores\Hubspot\Resources\DealProperties dealproperties()
  * @method \SevenShores\Hubspot\Resources\Deals deals()
  * @method \SevenShores\Hubspot\Resources\Owners owners()
+ * @method \SevenShores\Hubspot\Resources\SingleSend singleSend()
  */
 class Factory
 {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -29,7 +29,7 @@ use SevenShores\Hubspot\Http\Client;
  * @method \SevenShores\Hubspot\Resources\DealProperties dealproperties()
  * @method \SevenShores\Hubspot\Resources\Deals deals()
  * @method \SevenShores\Hubspot\Resources\Owners owners()
- * @method \SevenShores\Hubspot\Resources\SingleSend singleSend()
+ * @method \SevenShores\Hubspot\Resources\SingleEmail singleEmail()
  */
 class Factory
 {

--- a/src/Resources/SingleEmail.php
+++ b/src/Resources/SingleEmail.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace SevenShores\Hubspot\Resources;
+
+class SingleEmail extends Resource
+{
+    /**
+     * Send an email designed and maintained in the HubSpot marketing Email Tool.
+     *
+     * @param array  $params
+     * @return \SevenShores\Hubspot\Http\Response
+     */
+    function send($id, $message = [], $contactProperties = [], $customProperties = [])
+    {
+        $endpoint = "https://api.hubapi.com/email/public/v1/singleEmail/send";
+
+        $options['json'] = [
+          'emailId'           => $id,
+          'message'           => $message
+          'contactProperties' => $contactProperties,
+          'customProperties'  => $customProperties
+        ];
+
+        return $this->client->request('post', $endpoint, $options);
+    }
+}

--- a/src/Resources/SingleEmail.php
+++ b/src/Resources/SingleEmail.php
@@ -16,7 +16,7 @@ class SingleEmail extends Resource
 
         $options['json'] = [
           'emailId'           => $id,
-          'message'           => $message
+          'message'           => $message,
           'contactProperties' => $contactProperties,
           'customProperties'  => $customProperties
         ];

--- a/src/Resources/SingleEmail.php
+++ b/src/Resources/SingleEmail.php
@@ -7,7 +7,12 @@ class SingleEmail extends Resource
     /**
      * Send an email designed and maintained in the HubSpot marketing Email Tool.
      *
-     * @param array  $params
+     * @see http://developers.hubspot.com/docs/methods/email/transactional_email/single-send-overview
+     *
+     * @param int    $id
+     * @param array  $message
+     * @param array  $contactProperties
+     * @param array  $customProperties
      * @return \SevenShores\Hubspot\Http\Response
      */
     function send($id, $message = [], $contactProperties = [], $customProperties = [])


### PR DESCRIPTION
Adds support for the Single Send API (part of the Transactional Email Add-on – http://developers.hubspot.com/docs/methods/email/transactional_email/single-send-overview)