### PR TITLE
Add support for event type data in Timeline events.

### DIFF
--- a/src/Resources/Timeline.php
+++ b/src/Resources/Timeline.php
@@ -15,6 +15,7 @@ class Timeline extends Resource
      * @param string|null $utk
      * @param array       $extraData
      * @param mixed       $timestamp
+     * @param array       $eventTypeData
      *
      * @return mixed
      *
@@ -28,11 +29,12 @@ class Timeline extends Resource
         $email = null,
         $utk = null,
         $extraData = [],
-        $timestamp = null
+        $timestamp = null,
+        $eventTypeData = []
     ) {
         $endpoint = "https://api.hubapi.com/integrations/v1/{$appId}/timeline/event";
 
-        $data['json'] = [
+        $data['json'] = array_merge([
             'eventTypeId' => $eventTypeId,
             'id'          => $id,
             'objectId'    => $objectId,
@@ -40,7 +42,7 @@ class Timeline extends Resource
             'utk'         => $utk,
             'extraData'   => $extraData,
             'timestamp'   => $this->timestamp($timestamp),
-        ];
+        ], $eventTypeData);
 
         return $this->client->request('put', $endpoint, $data);
     }


### PR DESCRIPTION
This PR adds support for sending custom event type data in Timeline events. As you can see, there was already support for `extraData`, but `extraData` isn't segment-able on Timeline events like custom event type data is.

If you take a look at section 4 (http://developers.hubspot.com/docs/methods/timeline/timeline-overview) "Creating an Event" there's an example that shows custom data in the JSON body directly:

```bash
curl -X PUT -H "Content-Type: application/json" -d '
{
  "id": "001-001001",
  "eventTypeId": <<eventTypeId>>,
  "webinarName": "A Test Webinar",
  "webinarId": "001001",
  "email": "a.test.contact@email.com"
}' \
https://api.hubapi.com/integrations/v1/<<applicationId>>/timeline/event?access_token=<<OAuthAccessToken>>
```