### PR TITLE
OAuth2 support

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -46,6 +46,10 @@ class Client
 
         $this->oauth = isset($config["oauth"]) ? $config["oauth"] : false;
         $this->oauth2 = isset($config["oauth2"]) ? $config["oauth2"] : false;
+        if ($this->oauth && $this->oauth2) {
+            throw new InvalidArgument("Cannot sign requests with both OAuth1 and OAuth2");
+        }
+
         $this->client = $client ?: new GuzzleClient();
     }
 


### PR DESCRIPTION
Recently, HubSpot rolled out their new authentication which is OAuth2. OAuth1 is still currently supported, and will be for quite some time since they're just now making the transition (I sent an email asking someone about that and got that confirmation), so both forms of OAuth should be supported.

http://developers.hubspot.com/docs/methods/oauth2/oauth2-overview

As mentioned in #50, I don't think this library should have anything to do with generating the access tokens or refreshing them, but just another way to sign the request. The difference here is that instead of signing requests `?access_token=token` we now sign them with an [Authorization header](http://developers.hubspot.com/docs/methods/oauth2/using-access-tokens):

```
Authorization: Bearer {token}
```