### PR TITLE
[FEATURE] Allow passing of request options and own error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,25 @@ $hubspot = new SevenShores\Hubspot\Factory([
 ```
 *Note:* The Client class checks for a `HUBSPOT_SECRET` environment variable if you don't include an api key or oauth token during instantiation.
 
+*Note:* You can prevent any error handling provided by this package by passing following options into client creation routine:
+(applies also to `Factory::create()` and `Factory::createWithToken()`)
+
+```php
+$hubspot = new SevenShores\Hubspot\Factory([
+  'key'      => 'demo',
+  'oauth'    => false, // default
+  'base_url' => 'https://api.hubapi.com' // default
+],
+[
+  'http_errors' = true // pass any Guzzle related option to any request, e.g. throw no exceptions
+],
+false // return Guzzle Response object for any ->request(*) call
+);
+```
+
+By setting `http_errors` to true, you will not receive any exceptions at all, but pure responses.
+For possible options, see http://docs.guzzlephp.org/en/latest/request-options.html.
+
 #### Get a single contact:
 
 ```php

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -38,36 +38,42 @@ class Factory
     /**
      * C O N S T R U C T O R ( ^_^)y
      *
-     * @param  array   $config  An array of configurations. You need at least the 'key'.
-     * @param  Client  $client
+     * @param  array $config An array of configurations. You need at least the 'key'.
+     * @param  Client $client
+     * @param array $clientOptions options to be send with each request
+     * @param bool $wrapResponse wrap request response in own Response object
      */
-    function __construct($config = [], $client = null)
+    public function __construct($config = [], $client = null, $clientOptions = [], $wrapResponse = true)
     {
-        $this->client = $client ?: new Client($config);
+        $this->client = $client ?: new Client($config, null, $clientOptions, $wrapResponse);
     }
 
     /**
      * Create an instance of the service with an API key.
      *
-     * @param  string  $api_key  Hubspot API key.
-     * @param  Client  $client   An Http client.
+     * @param  string $api_key Hubspot API key.
+     * @param  Client $client An Http client.
+     * @param array $clientOptions options to be send with each request
+     * @param bool $wrapResponse wrap request response in own Response object
      * @return static
      */
-    static function create($api_key = null, $client = null)
+    public static function create($api_key = null, $client = null, $clientOptions = [], $wrapResponse = true)
     {
-        return new static(['key' => $api_key], $client);
+        return new static(['key' => $api_key], $client, $clientOptions, $wrapResponse);
     }
 
     /**
      * Create an instance of the service with an Oauth token.
      *
-     * @param  string  $token   Hubspot oauth access token.
-     * @param  Client  $client  An Http client.
+     * @param  string $token Hubspot oauth access token.
+     * @param  Client $client An Http client.
+     * @param array $clientOptions options to be send with each request
+     * @param bool $wrapResponse wrap request response in own Response object
      * @return static
      */
-    static function createWithToken($token, $client = null)
+    public static function createWithToken($token, $client = null, $clientOptions = [], $wrapResponse = true)
     {
-        return new static(['key' => $token, 'oauth' => true], $client);
+        return new static(['key' => $token, 'oauth' => true], $client, $clientOptions, $wrapResponse);
     }
 
     /**


### PR DESCRIPTION
With this change, it is now possible to set options to be passed
with the request method on a per callee level. Each client creation
is able to accept options, that will be applied to each call to
any request function and be respected by Guzzle Requests.
The default behaviour will be as before that change.

Additionally, the exception handling and the Response wrapping
into a SevenShores\Hubspot\Http\Response object can be avoided.
So it is possible to care for the error handling in the own
application.
Again, the default behaviour remains unchanged, the response
is wrapped and SevenShores\Hubspot\Exceptions are thrown.