### PR TITLE
Get full error message

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -99,6 +99,8 @@ class Client
                 return $this->client->request($method, $url, $options);
             }
             return new Response($this->client->request($method, $url, $options));
+        } catch (\GuzzleHttp\Exception\BadResponseException $e) {
+            throw new BadRequest(\GuzzleHttp\Psr7\str($e->getResponse()), $e->getCode(), $e);
         } catch (\Exception $e) {
             throw new BadRequest($e->getMessage(), $e->getCode(), $e);
         }


### PR DESCRIPTION
Guzzle truncates Exception->getMessage(). Use \GuzzleHttp\Psr7\str($e->getResponse()) instead.