### PR TITLE
Correctly call Events API.

### DIFF
--- a/src/Resources/Events.php
+++ b/src/Resources/Events.php
@@ -13,7 +13,7 @@ class Events extends Resource
      *                                     footer of the HubSpot UI, or in the URL. For example, in this URL:
      *                                     "https://app.hubspot.com/reports/56043/events/" your Hub ID is "56043".
      * @param  string $eventId
-     * @param  string $contactEmail        Optional - contact email.
+     * @param  string $contactEmail        Contact email triggering the event.
      * @param  float  $contactRevenue      Optional - the monetary value this event means to you.
      * @param  array  $contactProperties   Optional - array of new contact properties.
      * @return \SevenShores\Hubspot\Http\Response
@@ -25,16 +25,19 @@ class Events extends Resource
         $contactRevenue = null,
         $contactProperties = []
     ) {
-        $endpoint = sprintf(
-            "http://track.hubspot.com/v1/event?_a=%s&_n=%s",
-            url_encode($hubId),
-            url_encode($eventId)
+        $endpoint = "http://track.hubspot.com/v1/event";
+
+        $required['_a'] = $hubId;
+        $required['_n'] = $eventId;
+        $required['email'] = $contactEmail;
+
+        $parameters = array_merge(
+          $required,
+          ['_m' => $contactRevenue],
+          $contactProperties
         );
 
-        $contactProperties['email'] = $contactEmail;
-        $contactProperties['_m'] = $contactRevenue;
-
-        $query_string = build_query_string($contactProperties);
+        $query_string = build_query_string($parameters);
 
         return $this->client->request('get', $endpoint, [], $query_string);
     }


### PR DESCRIPTION
The Hubspot Event API seems to be called slightly differently than other HS API endpoints. All parameters to the endpoint are in the querystring, whereas it seems other endpoints (contact: _/contacts/v1/contact/vid/:contact_id/profile_) take parameters as part of the URL, and then optional querystring parameters.

Currently, calling this class `$hubspot->events()->trigger('123', '12345', 'test@example.com');` (psuedo-code) with in this manner results in a request to:
```
http://track.hubspot.com/v1/event?_a=123&_n=12345?email=test@example.com
```
_Note the two "?"_

Anyways, this results in a 200 status code, it just records the events incorrectly on the hubspot side, so I can't even update the tests for this PR. This PR changes the events call to add all parameters to the querystring, and calls the static endpoint with all known parameters.

After submitting this PR, I will pull this patch into project and test a little to ensure this accomplishes what I need it to. I'm happy to update the code style to the maintainers preferences (do I need all these local variables) so please feel free to leave any feedback and I will update ASAP.

