### PR TITLE
Add optional param to Contacts getByEmail function

### DIFF
--- a/src/Resources/Contacts.php
+++ b/src/Resources/Contacts.php
@@ -130,13 +130,17 @@ class Contacts extends Resource
 
     /**
      * @param int $id
+     * @param array $params Array of optional parameters ['property', 'propertyMode', 'formSubmissionMode',
+     *                      'showListMemberships']
      * @return \SevenShores\Hubspot\Http\Response
      */
-    function getById($id)
+    function getById($id, $params = [])
     {
         $endpoint = "https://api.hubapi.com/contacts/v1/contact/vid/{$id}/profile";
 
-        return $this->client->request('get', $endpoint);
+        $queryString = build_query_string($params);
+
+        return $this->client->request('get', $endpoint, [], $queryString);
     }
 
     /**
@@ -205,13 +209,17 @@ class Contacts extends Resource
 
     /**
      * @param string $utk
+     * @param array $params Array of optional parameters ['property', 'propertyMode', 'formSubmissionMode',
+     *                      'showListMemberships']
      * @return \SevenShores\Hubspot\Http\Response
      */
-    function getByToken($utk)
+    function getByToken($utk, $params = [])
     {
         $endpoint = "https://api.hubapi.com/contacts/v1/contact/utk/{$utk}/profile";
 
-        return $this->client->request('get', $endpoint);
+        $queryString = build_query_string($params);
+
+        return $this->client->request('get', $endpoint, [], $queryString);
     }
 
     /**

--- a/src/Resources/Contacts.php
+++ b/src/Resources/Contacts.php
@@ -166,13 +166,17 @@ class Contacts extends Resource
 
     /**
      * @param string $email
+     * @param array $params Array of optional parameters ['property', 'propertyMode', 'formSubmissionMode',
+     *                      'showListMemberships']
      * @return \SevenShores\Hubspot\Http\Response
      */
-    function getByEmail($email)
+    function getByEmail($email, $params = [])
     {
         $endpoint = "https://api.hubapi.com/contacts/v1/contact/email/{$email}/profile";
 
-        return $this->client->request('get', $endpoint);
+        $queryString = build_query_string($params);
+
+        return $this->client->request('get', $endpoint, [], $queryString);
     }
 
     /**


### PR DESCRIPTION
As describe here [https://developers.hubspot.com/docs/methods/contacts/get_contact_by_email](https://developers.hubspot.com/docs/methods/contacts/get_contact_by_email) we can also pass optional param to filter results.