### PR TITLE
Fixed parameter name for createFolder()

### DIFF
--- a/src/Resources/Files.php
+++ b/src/Resources/Files.php
@@ -142,7 +142,7 @@ class Files extends Resource
         $endpoint = "https://api.hubapi.com/filemanager/api/v2/folders";
 
         $options['json'] = [
-            'folder_name'      => $folder_name,
+            'name'             => $folder_name,
             'parent_folder_id' => $parent_folder_id,
         ];
 


### PR DESCRIPTION
Fixed parameter name, as per https://developers.hubspot.com/docs/methods/files/post_folders

There's one error in unit test but unrelated to this fix.

```1) SevenShores\Hubspot\Tests\Integration\Resources\TimelineTest::createOrUpdateBatch
SevenShores\Hubspot\Exceptions\BadRequest: HTTP/1.1 403 Forbidden
Access-Control-Allow-Credentials: false
Content-Type: application/json; charset=UTF-8
Content-Length: 175
Date: Fri, 22 Sep 2017 15:40:25 GMT
Connection: close

{"status":"error","message":"You don't have access to this application.","correlationId":"0bbc3531-c8a3-43ec-ba83-5a1f466c7e25","requestId":"f81c130efac5229c405be6176729162a"}```