### PR TITLE
[FEATURE] New endpoint for company->searchByDomain

### DIFF
--- a/src/Resources/Companies.php
+++ b/src/Resources/Companies.php
@@ -120,6 +120,32 @@ class Companies extends Resource
     }
 
     /**
+     * @param string $domain
+     * @param array $properties
+     * @param int $limit
+     * @param int $offset
+     *
+     * @see https://developers.hubspot.com/docs/methods/companies/search_companies_by_domain
+     *
+     * @return \Psr\Http\Message\ResponseInterface|\SevenShores\Hubspot\Http\Response
+     */
+    public function searchByDomain($domain, $properties = [], $limit = 100, $offset = 0)
+    {
+        $endpoint = "https://api.hubapi.com/companies/v2/domains/{$domain}/companies";
+        $options['json'] = [
+            'limit' => $limit,
+            'offset' => [
+                'isPrimary' => true,
+                'companyId' => $offset
+            ],
+            'requestOptions' => [
+                'properties' => $properties
+            ]
+        ];
+        return $this->client->request('post', $endpoint, $options);
+    }
+
+    /**
      * Returns a company with id $id
      * @param int $id
      *

--- a/tests/integration/Resources/CompaniesTest.php
+++ b/tests/integration/Resources/CompaniesTest.php
@@ -233,6 +233,17 @@ class CompaniesTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @test
+     */
+    public function searchCompanyByDomain()
+    {
+        $response = $this->companies->searchByDomain('hubspot.com', ['name', 'domain']);
+        $this->assertEquals(200, $response->getStatusCode());
+        $results = $response->getData();
+        $this->assertEquals('Hubspot, Inc', current($results)[0]->properties->domain->value);
+    }
+
+    /**
      * Creates a Company with the HubSpotApi
      *
      * @return \SevenShores\Hubspot\Http\Response


### PR DESCRIPTION
The old endpoint GET company->getByDomain is deprecated.
See new endpoint documentation: https://developers.hubspot.com/docs/methods/companies/search_companies_by_domain

Resolves: #127