### PR TITLE
API fix for folders as well as Guzzle warnings for file replace

### DIFF
--- a/src/Resources/Files.php
+++ b/src/Resources/Files.php
@@ -63,8 +63,11 @@ class Files extends Resource
     {
         $endpoint = "https://api.hubapi.com/filemanager/api/v2/files/{$file_id}";
 
-        $options['body'] = [
-            'files' => fopen($file, 'rb'),
+        $options['multipart'] = [
+            [
+                'name' => 'files',
+                'contents' => fopen($file, 'rb')
+            ]
         ];
 
         return $this->client->request('post', $endpoint, $options);

--- a/src/Resources/Files.php
+++ b/src/Resources/Files.php
@@ -159,9 +159,9 @@ class Files extends Resource
     {
         $endpoint = "https://api.hubapi.com/filemanager/api/v2/folders";
 
-        $options['json'] = $params;
+        $queryString = build_query_string($params);
 
-        return $this->client->request('get', $endpoint, $options);
+        return $this->client->request('get', $endpoint, [], $queryString);
     }
 
     /**


### PR DESCRIPTION
Includes the previous API fix for folders as well as an update to the files replace function where Guzzle was warning about the deprecated use of "body" to send the file data.