### PR TITLE
The associated API call should allow offset and limit

### DIFF
--- a/src/Resources/Engagements.php
+++ b/src/Resources/Engagements.php
@@ -24,7 +24,7 @@ class Engagements extends Resource
 
         return $this->client->request('post', $endpoint, $options);
     }
-    
+
     /**
      * Returns all recently created or updated engagements.
      *
@@ -113,16 +113,17 @@ class Engagements extends Resource
 
         return $this->client->request('put', $endpoint);
     }
-    
+
     /**
      * @param string $object_type
      * @param int $object_id
+     * @param array $params Array of optional parameters ['limit', 'offset']
      * @return \SevenShores\Hubspot\Http\Response
      **/
-    function associated($object_type, $object_id)
+    function associated($object_type, $object_id, $params = [])
     {
         $endpoint = "https://api.hubapi.com/engagements/v1/engagements/associated/{$object_type}/{$object_id}/paged";
-
-        return $this->client->request('get', $endpoint);
+        $queryString = build_query_string($params);
+        return $this->client->request('get', $endpoint, [], $queryString);
     }
 }

--- a/src/Resources/Files.php
+++ b/src/Resources/Files.php
@@ -63,8 +63,11 @@ class Files extends Resource
     {
         $endpoint = "https://api.hubapi.com/filemanager/api/v2/files/{$file_id}";
 
-        $options['body'] = [
-            'files' => fopen($file, 'rb'),
+        $options['multipart'] = [
+            [
+                'name' => 'files',
+                'contents' => fopen($file, 'rb')
+            ]
         ];
 
         return $this->client->request('post', $endpoint, $options);

--- a/src/Resources/Files.php
+++ b/src/Resources/Files.php
@@ -159,9 +159,9 @@ class Files extends Resource
     {
         $endpoint = "https://api.hubapi.com/filemanager/api/v2/folders";
 
-        $options['json'] = $params;
+        $queryString = build_query_string($params);
 
-        return $this->client->request('get', $endpoint, $options);
+        return $this->client->request('get', $endpoint, [], $queryString);
     }
 
     /**


### PR DESCRIPTION
When calling the engagements/associated API the params for offset and limit should be able to be specified.