### PR TITLE
Fixing bug in cloning pages/posts endpoint

### DIFF
--- a/src/Resources/Pages.php
+++ b/src/Resources/Pages.php
@@ -102,17 +102,20 @@ class Pages extends Resource
         return $this->client->request('get', $endpoint);
     }
 
-    /**
-     * Clone the page.
-     *
-     * @param int $page_id The page ID
-     * @return \SevenShores\Hubspot\Http\Response
-     */
-    function clonePage($page_id)
+	/**
+	 * Clone the page.
+	 *
+	 * @param int $page_id The page ID
+	 * @param string $name The cloned page name
+	 * @return \SevenShores\Hubspot\Http\Response
+	 */
+    function clonePage($page_id, $name)
     {
         $endpoint = "https://api.hubapi.com/content/api/v2/pages/{$page_id}/clone";
 
-        return $this->client->request('post', $endpoint);
+        $options['json'] = ['name' => $name];
+
+        return $this->client->request('post', $endpoint, $options);
     }
 
     /**

--- a/tests/integration/Resources/BlogPostsTest.php
+++ b/tests/integration/Resources/BlogPostsTest.php
@@ -116,9 +116,9 @@ class BlogPostsTest extends \PHPUnit_Framework_TestCase
     {
         $post = $this->createBlogPost();
 
-        $response = $this->blogPosts->clonePost($post->id);
+        $response = $this->blogPosts->clonePost($post->id, 'Cloned post name');
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(201, $response->getStatusCode());
     }
 
     /** @test */

--- a/tests/integration/Resources/PagesTest.php
+++ b/tests/integration/Resources/PagesTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace SevenShores\Hubspot\Tests\Integration\Resources;
+
+use SevenShores\Hubspot\Http\Client;
+use SevenShores\Hubspot\Resources\Pages;
+
+class PagesTest extends \PHPUnit_Framework_TestCase
+{
+	private $pages;
+
+	public function setUp()
+	{
+		parent::setUp();
+		$this->pages = new Pages(new Client(['key' => 'demo']));
+		sleep(1);
+	}
+
+	/*
+     * Lots of tests need an existing object to modify.
+     */
+	private function createPage()
+	{
+		sleep(1);
+
+		$response = $this->pages->create([
+			'name'             => 'My Super Awesome Post ' . uniqid(),
+			'content_group_id' => 351076997,
+		]);
+
+		$this->assertEquals(201, $response->getStatusCode());
+		return $response;
+	}
+
+	/** @test */
+	public function clonePage()
+	{
+		$post = $this->createPage();
+		$response = $this->pages->clonePage($post->id, 'New page name');
+		$this->assertEquals(201, $response->getStatusCode());
+	}
+
+}


### PR DESCRIPTION
Found a bug in both the test and implementation of cloning pages/blog posts.

This PR fixes both issues.