### PR TITLE
Allow optional params for contacts batch create/update

### DIFF
--- a/src/Resources/Contacts.php
+++ b/src/Resources/Contacts.php
@@ -62,15 +62,18 @@ class Contacts extends Resource
 
     /**
      * @param array $contacts The contacts and properties.
+     * @param array $params Array of optional parameters ['auditId']
      * @return \SevenShores\Hubspot\Http\Response
      */
-    function createOrUpdateBatch($contacts)
+    function createOrUpdateBatch($contacts, $params = [])
     {
         $endpoint = "https://api.hubapi.com/contacts/v1/contact/batch";
 
+        $queryString = build_query_string($params);
+
         $options['json'] = $contacts;
 
-        return $this->client->request('post', $endpoint, $options);
+        return $this->client->request('post', $endpoint, $options, $queryString);
     }
 
     /**

--- a/tests/integration/Resources/ContactsTest.php
+++ b/tests/integration/Resources/ContactsTest.php
@@ -134,6 +134,30 @@ class ContactsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(202, $response->getStatusCode());
     }
 
+
+    /** @test */
+    public function createOrUpdateBatchWithAuditId()
+    {
+        $response = $this->contacts->createOrUpdateBatch([
+            [
+                'email' => 'test1@hubspot.com',
+                'properties' => [
+                    ['property' => 'firstname', 'value' => 'joe'],
+                    ['property' => 'lastname', 'value'  => 'user'],
+                ],
+            ],
+            [
+                'email' => 'test2@hubspot.com',
+                'properties' => [
+                    ['property' => 'firstname', 'value' => 'jane'],
+                    ['property' => 'lastname', 'value'  => 'user'],
+                ],
+            ]
+        ],['auditId' => 'TEST_CHANGE_SOURCE']);
+
+        $this->assertEquals(202, $response->getStatusCode());
+    }
+
     /** @test */
     public function delete()
     {


### PR DESCRIPTION
as per api docs;
https://developers.hubspot.com/docs/methods/contacts/batch_create_or_update
has optional parameter Change Source (&auditId)