### PR TITLE
Adding support for ECommerce Bridge API

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -35,6 +35,7 @@ use SevenShores\Hubspot\Http\Client;
  * @method \SevenShores\Hubspot\Resources\Owners owners()
  * @method \SevenShores\Hubspot\Resources\SingleEmail singleEmail()
  * @method \SevenShores\Hubspot\Resources\Integration integration()
+ * @method \SevenShores\Hubspot\Resources\EcommerceBridge ecommerceBridge()
  */
 class Factory
 {

--- a/src/Resources/EcommerceBridge.php
+++ b/src/Resources/EcommerceBridge.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace SevenShores\Hubspot\Resources;
+
+class EcommerceBridge extends Resource
+{
+    /**
+     * Installs the ecommerce bridge into a portal.
+     *
+     * @return \SevenShores\Hubspot\Http\Response
+     * @throws \SevenShores\Hubspot\Exceptions\BadRequest
+     */
+    function install()
+    {
+        $endpoint = 'https://api.hubapi.com/extensions/ecomm/v1/installs';
+
+        return $this->client->request('post', $endpoint);
+    }
+
+    /**
+     * Check the status of the ecommerce bridge.
+     *
+     * @return \SevenShores\Hubspot\Http\Response
+     * @throws \SevenShores\Hubspot\Exceptions\BadRequest
+     */
+    function checkInstall()
+    {
+        $endpoint = 'https://api.hubapi.com/extensions/ecomm/v1/installs/status';
+
+        return $this->client->request('get', $endpoint);
+    }
+
+    /**
+     * Uninstall the ecommerce settings from a portal.
+     *
+     * @return \SevenShores\Hubspot\Http\Response
+     * @throws \SevenShores\Hubspot\Exceptions\BadRequest
+     */
+    function uninstall()
+    {
+        $endpoint = 'https://api.hubapi.com/extensions/ecomm/v1/installs/uninstall';
+
+        return $this->client->request('post', $endpoint);
+    }
+
+    /**
+     * Create or update the ecommerce settings.
+     *
+     * @param  array $settings
+     * @return \SevenShores\Hubspot\Http\Response
+     * @throws \SevenShores\Hubspot\Exceptions\BadRequest
+     */
+    function upsertSettings($settings = [])
+    {
+        $endpoint = 'https://api.hubapi.com/extensions/ecomm/v1/settings';
+
+        $options['json'] = $settings;
+
+        return $this->client->request('put', $endpoint, $options);
+    }
+
+    /**
+     * Delete the ecommerce settings for your app or portal.
+     * Note: This action cannot be undone. If you want to disable sync messages from being applied, it is recommended that you disable the settings rather than deleting them.
+     *
+     * @return \SevenShores\Hubspot\Http\Response
+     * @throws \SevenShores\Hubspot\Exceptions\BadRequest
+     */
+    function deleteSettings()
+    {
+        $endpoint = 'https://api.hubapi.com/extensions/ecomm/v1/settings';
+
+        return $this->client->request('delete', $endpoint);
+    }
+
+    /**
+     * Send a group of sync messages for a specific object type. Sync messages would be notifications of creates, updates, or deletes of ecommerce objects.
+     *
+     * @param  string $objectType - The object type that the updates are for. One of CONTACT, DEAL, PRODUCT, or LINE_ITEM.
+     * @param  array  $messages
+     * @return \SevenShores\Hubspot\Http\Response
+     * @throws \SevenShores\Hubspot\Exceptions\BadRequest
+     */
+    function sendSyncMessages($objectType, $messages = [])
+    {
+        $endpoint = "https://api.hubapi.com/extensions/ecomm/v1/sync-messages/{$objectType}";
+
+        $options['json'] = $messages;
+
+        return $this->client->request('put', $endpoint, $options);
+    }
+
+    /**
+     * Get errors from previously processed sync messages.
+     *
+     * @return \SevenShores\Hubspot\Http\Response
+     * @throws \SevenShores\Hubspot\Exceptions\BadRequest
+     */
+    function getSyncErrors()
+    {
+        $endpoint = 'https://api.hubapi.com/extensions/ecomm/v1/sync-errors';
+
+        return $this->client->request('get', $endpoint);
+    }
+
+    /**
+     * Set the URI for the import initialization webhook.
+     *
+     * @param  string $importTriggerUri - The URI that will be hit with the import webhook.
+     * @return \SevenShores\Hubspot\Http\Response
+     * @throws \SevenShores\Hubspot\Exceptions\BadRequest
+     */
+    function setImportUri($importTriggerUri)
+    {
+        $endpoint = 'https://api.hubapi.com/extensions/ecomm/v1/import-settings';
+
+        $options['json'] = [
+            'importTriggerUri' => $importTriggerUri
+        ];
+
+        return $this->client->request('put', $endpoint, $options);
+    }
+
+    /**
+     * Retrieve the ecommerce import settings for an app.
+     *
+     * @return \SevenShores\Hubspot\Http\Response
+     * @throws \SevenShores\Hubspot\Exceptions\BadRequest
+     */
+    function getImportSettings()
+    {
+        $endpoint = 'https://api.hubapi.com/extensions/ecomm/v1/import-settings';
+
+        return $this->client->request('get', $endpoint);
+    }
+
+    /**
+     * @param  int    $importStartedAt - Timestamp from the import initialization request
+     * @param  string $objectType      - The object type this data corresponds to. Must be one of CONTACT, DEAL, LINE_ITEM, or PRODUCT.
+     * @param  int    $pageNumber      - A numeric page number that identifies this page of data
+     * @param  array  $messages        - The import messages
+     * @return \SevenShores\Hubspot\Http\Response
+     * @throws \SevenShores\Hubspot\Exceptions\BadRequest
+     */
+    function importObjects($importStartedAt, $objectType, $pageNumber, $messages)
+    {
+        $endpoint = "https://api.hubapi.com/import-pages/{$importStartedAt}/{$objectType}/{$pageNumber}";
+
+        $options['json'] = $messages;
+
+        return $this->client->request('put', $endpoint, $options);
+    }
+
+    /**
+     * @param  int    $importStartedAt - Timestamp from the import initialization request
+     * @param  string $objectType      - The object type this data corresponds to. Must be one of CONTACT, DEAL, LINE_ITEM, or PRODUCT.
+     * @param  int    $pageCount       - The total number of pages sent via the import pages endpoint.
+     * @param  int    $itemCount       - The total number of items sent via the import pages endpoint.
+     * @return \SevenShores\Hubspot\Http\Response
+     * @throws \SevenShores\Hubspot\Exceptions\BadRequest
+     */
+    function signalImportEnd($importStartedAt, $objectType, $pageCount, $itemCount)
+    {
+        $endpoint = "https://api.hubapi.com/import-pages/{$importStartedAt}/{$objectType}/end";
+
+        $options['json'] = [
+            'pageCount' => $pageCount,
+            'itemCount' => $itemCount
+        ];
+
+        return $this->client->request('put', $endpoint, $options);
+    }
+}

--- a/tests/integration/Resources/EcommerceBridgeTest.php
+++ b/tests/integration/Resources/EcommerceBridgeTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace SevenShores\Hubspot\Tests\integration\Resources;
+
+use SevenShores\Hubspot\Http\Client;
+use SevenShores\Hubspot\Resources\EcommerceBridge;
+
+/**
+ * Class EcommerceBridgeTest
+ * @package SevenShores\Hubspot\Tests\Integration\Resources
+ * @group ecommerceBridge
+ */
+class EcommerceBridgeTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var EcommerceBridge */
+    private $ecommerceBridge;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->ecommerceBridge = new EcommerceBridge(new Client(['key' => 'demo']));
+        sleep(1);
+    }
+
+    public function testInstall()
+    {
+        $response = $this->ecommerceBridge->install();
+
+        $this->assertEquals(204, $response->getStatusCode());
+    }
+
+//    TODO: add back in once hubspot stops throwing 500 errors
+//    public function testCheckInstall()
+//    {
+//        $response = $this->ecommerceBridge->checkInstall();
+//
+//        $this->assertEquals(200, $response->getStatusCode());
+//        $this->assertContains([
+//            'installCompleted' => true
+//        ], $response->toArray());
+//    }
+
+    public function testUninstallSettings()
+    {
+        $response = $this->ecommerceBridge->uninstall();
+
+        $this->assertEquals(204, $response->getStatusCode());
+    }
+
+    public function testUpsertSettings()
+    {
+        $settings = [
+            'enabled' => false,
+            'importOnInstall' => false,
+            'productSyncSettings' => [
+                'properties' => [
+                    ['propertyName' => 'test_name', 'dataType' => 'STRING', 'targetHubspotProperty' => 'name']
+                ]
+            ],
+            'dealSyncSettings' => [
+                'properties' => []
+            ],
+            'lineItemSyncSettings' => [
+                'properties' => []
+            ],
+            'contactSyncSettings' => [
+                'properties' => []
+            ]
+        ];
+
+        $response = $this->ecommerceBridge->upsertSettings($settings);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals($settings, $response->toArray());
+    }
+
+    public function testDeleteSettings()
+    {
+        $response = $this->ecommerceBridge->deleteSettings();
+
+        $this->assertEquals(204, $response->getStatusCode());
+    }
+
+    public function testSyncErrors()
+    {
+        $response = $this->ecommerceBridge->getSyncErrors();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertArrayHasKey('results', $response->toArray());
+    }
+}


### PR DESCRIPTION
Hello! 👋 

I've added support for the new [ECommerce Bridge API](https://developers.hubspot.com/docs/methods/ecomm-bridge/ecomm-bridge-overview). Based on #140 and weird API inconsistencies with the `demo` api key, I wasn't sure how comprehensive to make the unit tests. However, I have included some tests for the endpoints that were working consistently for me.

Let me know if there's anything you'd like to change. Thanks!