### PR TITLE
Bugfix where wrong HTTP verb was used to update table row in HubDB

### DIFF
--- a/src/Resources/HubDB.php
+++ b/src/Resources/HubDB.php
@@ -140,6 +140,6 @@ class HubDB extends Resource
         $endpoint = 'https://api.hubapi.com/hubdb/api/v1/tables/'.$tableId.'/rows/'.$rowId;
         $options['json'] = ['values' => $values];
 
-        return $this->client->request('post', $endpoint, $options);
+        return $this->client->request('put', $endpoint, $options);
     }
 }


### PR DESCRIPTION
Breaking bug where Hubspot throws 405 method not allowed error.