### PR TITLE
Create endpoint for batch-updating deals

### DIFF
--- a/src/Resources/Deals.php
+++ b/src/Resources/Deals.php
@@ -34,6 +34,23 @@ class Deals extends Resource
     }
 
     /**
+     * Update a group of existing deal records by their dealId.
+     *
+     * @see https://developers.hubspot.com/docs/methods/deals/batch-update-deals
+     *
+     * @param array $deals The deals and properties.
+     * @return \SevenShores\Hubspot\Http\Response
+     */
+    function updateBatch(array $deals)
+    {
+        $endpoint = "https://api.hubapi.com/deals/v1/batch-async/update";
+
+        $options['json'] = $deals;
+
+        return $this->client->request('post', $endpoint, $options);
+    }
+
+    /**
      * @param array $params
      *
      * @return \Psr\Http\Message\ResponseInterface|\SevenShores\Hubspot\Http\Response
@@ -135,7 +152,7 @@ class Deals extends Resource
 
         return $this->client->request('put', $endpoint, [], $queryString);
     }
-    
+
     /**
      * @param int $contactId
      * @param array $params Optional parameters ['limit', 'offset']

--- a/tests/integration/Resources/DealsTest.php
+++ b/tests/integration/Resources/DealsTest.php
@@ -122,6 +122,40 @@ class DealsTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function updateBatch()
+    {
+        $deal1 = $this->createDeal();
+        $deal2 = $this->createDeal();
+
+        $response = $this->deals->updateBatch([
+            [
+                'objectId' => $deal1->dealId,
+                'properties' => [
+                    ['name' => 'dealname', 'value'  => 'Even cooler Deal'],
+                    ['name' => 'amount', 'value' => '59999' ],
+                ],
+            ],
+            [
+                'objectId' => $deal2->dealId,
+                'properties' => [
+                    ['name' => 'dealname', 'value'  => 'Still ok Deal'],
+                ],
+            ]
+        ]);
+
+        $this->assertEquals(202, $response->getStatusCode());
+
+        $response = $this->deals->getById($deal1->dealId);
+        $this->assertSame('Even cooler Deal', $response['properties']['dealname']['value']);
+        $this->assertSame('59999', $response['properties']['amount']['value']);
+
+        $response = $this->deals->getById($deal2->dealId);
+        $this->assertSame('Still ok Deal', $response['properties']['dealname']['value']);
+    }
+
+    /**
+     * @test
+     */
     public function delete()
     {
         $response = $this->createDeal();


### PR DESCRIPTION
Created an endpoint allowing batch updates for deals. See:

https://developers.hubspot.com/docs/methods/deals/batch-update-deals

Tests are also included. The `delete` test in `tests/integration/Resources/DealTest` was failing in my case. But not due to my additions. I believe `getById` is throwing an exception because the deleted record isn't found (as it should be), causing the test to fail though. When I remove [these lines](https://github.com/ryanwinchester/hubspot-php/blob/0b42c86174f5cd54b0c2609814a3eee322363c6b/tests/integration/Resources/DealsTest.php#L134-L135) all deal tests pass.

